### PR TITLE
Join Now & Twitter Link Issue Fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@ document.body.removeChild(loader);
           </p>
           <!-- Text content for the Discord popup. -->
           <a
-            style="width: 140px; margin-left: 30px"
+            style="width: 140px; margin-left: 30px; color: white"
             href="https://discord.gg/J4F7nY97Fp"
             target="_blank"
             class="discord-link"

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@ document.body.removeChild(loader);
         class="social-icon facebook"
       ></a>
       <a
-        href="https://twitter.com"
+        href="https://twitter.com/ChromeGamingOn"
         target="_blank"
         class="social-icon twitter"
       ></a>

--- a/styles.css
+++ b/styles.css
@@ -335,7 +335,7 @@ body {
 .discord-link {
   display: block;
   margin-top: 20px;
-  background-color: #fff;
+  background-color: #7e7b7b;
   color: #000000;
   text-decoration: none;
   padding: 10px 20px;


### PR DESCRIPTION
## PR Description 📜

Join Now Text is Visible.  
Twitter from  Social Icons is linked to the Twitter Handle Page of Chrome Gaming.
Fixes #211 #228 

<hr>
 
## Mark the task you have completed ✅

<!----Please delete options that are not relevant. In order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [CONTRIBUTING GUIDELINE](https://github.com/GameSphere-MultiPlayer/Community-Page/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/GameSphere-MultiPlayer/Community-Page/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] My changes generates no new warnings.
- [x] I have followed proper naming convention showed in [CONTRIBUTING GUIDELINE](https://github.com/GameSphere-MultiPlayer/Community-Page/blob/main/.github/CONTRIBUTING_GUIDELINE.md)
- [x] I have added screenshot for review.


<hr>
## Screenshots Attested:

![joinNowText](https://github.com/ChromeGaming/Community-Page/assets/121930064/d04f32cc-671e-4e94-8460-4ee2073e588b)

![joinNowText2](https://github.com/ChromeGaming/Community-Page/assets/121930064/40867538-395d-400b-8688-2fc761a8c4c3)






--- 
<br>

## Thank you soo much for contributing to our repository 💗